### PR TITLE
fix xaxis scaling of ticks

### DIFF
--- a/frontend/controllers/dashboard/data_visualisation_controller.js
+++ b/frontend/controllers/dashboard/data_visualisation_controller.js
@@ -16,16 +16,16 @@ export default class extends Controller {
 
   lineChart() {
     if (this._lineChart === undefined) {
-      this.editStore("windowWidth", window.innerWidth)
+      this._windowWidth = window.innerWidth
       this._lineChart = new LineChart(this.store(), 60, "[data-viz='wrapper']", "[data-viz='tooltip']")
     }
     return this._lineChart
   }
 
   resize() {
-    if (window.innerWidth === this.store().windowWidth) return
+    if (window.innerWidth === this._windowWidth) return
 
-    this.editStore("windowWidth", window.innerWidth)
+    this._windowWidth = window.innerWidth
     this._lineChart = undefined
     const wrapper = document.querySelector("[data-viz='wrapper']")
     wrapper.removeChild(wrapper.lastChild)

--- a/frontend/javascripts/dashboard/LineChart.js
+++ b/frontend/javascripts/dashboard/LineChart.js
@@ -122,8 +122,11 @@ export default class LineChart {
       .scale(this.dv.yScale)
     this.dv.xAxisGenerator = d3.axisBottom()
       .scale(this.dv.xScale)
-      .tickValues(this.store.selectedContextData.map(data => data.build_number))
-      .tickFormat(d3.format(".0f"))
+    if (this.store.selectedContextData.length < 10) {
+      this.dv.xAxisGenerator = this.dv.xAxisGenerator
+        .tickValues(this.store.selectedContextData.map(data => data.build_number))
+        .tickFormat(d3.format(".0f"))
+    }
     // Duration line generator with animation
     this.dv.lineGenerator = d3.line()
       .x(d => this.dv.xScale(this.dv.xAccessor(d)))


### PR DESCRIPTION
The ticks were quite cramped on small screens when there was a lot of data. This PR fixes that issue by letting d3 figure out what number of ticks to use. I had to force the number when there were less than 10 builds because the tick spacing was breaking