### PR TITLE
touch position relative to listening rect

### DIFF
--- a/frontend/javascripts/dashboard/LineChart.js
+++ b/frontend/javascripts/dashboard/LineChart.js
@@ -341,7 +341,7 @@ export default class LineChart {
    **/
   closestDataPoint(event) {
     if (event instanceof TouchEvent) event = event.touches[0];
-    const mousePosition = d3.pointer(event)
+    const mousePosition = d3.pointer(event, event.target)
     const hoveredDate = this.dv.xScale.invert(mousePosition[0])
 
     const getDistanceFromHoveredDate = d => Math.abs(this.dv.xAccessor(d) - hoveredDate)


### PR DESCRIPTION
The touch position was always off to the right hand side. This PR corrects that by passing the target element to d3.pointer