### PR TITLE
dashboard no longer reloading on repeated visit

### DIFF
--- a/frontend/controllers/dashboard/build_time_by_context_controller.js
+++ b/frontend/controllers/dashboard/build_time_by_context_controller.js
@@ -22,8 +22,7 @@ export default class extends Controller {
   }
 
   /** 
-   * Handles a repeated Turbo visit to the dashboard page. Currently not valid as I've set page to reload
-   * because otheriwse d3 won't rebuild the visualisation
+   * Handles a repeated Turbo visit to the dashboard page.
    * 
    * @instance
    * @memberof Dashboard.BuildTimeByContextController

--- a/frontend/controllers/dashboard/data_visualisation_controller.js
+++ b/frontend/controllers/dashboard/data_visualisation_controller.js
@@ -18,7 +18,20 @@ export default class extends Controller {
   connect() {
     subscription(this)
     this.subscribe()
+    this.reconnect()
     this.resize = debounce(this.resize, 250).bind(this)
+  }
+
+  /** 
+   * Handles a repeated Turbo visit to the dashboard page.
+   * 
+   * @instance
+   * @memberof Dashboard.BuildTimeByContextController
+   **/
+  reconnect() {
+    if (this.store().selectedContextData) {
+      this.storeUpdated(this.store(), "selectedContextData")
+    }
   }
 
   /** 

--- a/frontend/controllers/dashboard/mean_build_times_controller.js
+++ b/frontend/controllers/dashboard/mean_build_times_controller.js
@@ -26,8 +26,7 @@ export default class extends Controller {
   }
 
   /** 
-   * Handles a repeated Turbo visit to the dashboard page. Currently not valid as I've set page to reload
-   * because otheriwse d3 won't rebuild the visualisation
+   * Handles a repeated Turbo visit to the dashboard page.
    * 
    * @instance
    * @memberof Dashboard.MeanBuildTimesController

--- a/frontend/controllers/dashboard/months_controller.js
+++ b/frontend/controllers/dashboard/months_controller.js
@@ -29,8 +29,7 @@ export default class extends Controller {
   }
 
   /** 
-   * Handles a repeated Turbo visit to the dashboard page. Currently not valid as I've set page to reload
-   * because otheriwse d3 won't rebuild the visualisation
+   * Handles a repeated Turbo visit to the dashboard page.
    * 
    * @instance
    * @memberof Dashboard.MonthsController

--- a/frontend/controllers/dashboard/successful_builds_controller.js
+++ b/frontend/controllers/dashboard/successful_builds_controller.js
@@ -24,8 +24,7 @@ export default class extends Controller {
   }
 
   /** 
-   * Handles a repeated Turbo visit to the dashboard page. Currently not valid as I've set page to reload
-   * because otheriwse d3 won't rebuild the visualisation
+   * Handles a repeated Turbo visit to the dashboard page.
    * 
    * @instance
    * @memberof Dashboard.SuccessfulBuildsController

--- a/frontend/controllers/dashboard/years_controller.js
+++ b/frontend/controllers/dashboard/years_controller.js
@@ -26,8 +26,7 @@ export default class extends Controller {
   }
 
   /** 
-   * Handles a repeated Turbo visit to the dashboard page. Currently not valid as I've set page to reload
-   * because otheriwse d3 won't rebuild the visualisation
+   * Handles a repeated Turbo visit to the dashboard page.
    * 
    * @instance
    * @memberof Dashboard.YearsController

--- a/source/dashboard/index.html.erb
+++ b/source/dashboard/index.html.erb
@@ -9,14 +9,6 @@ title: Netlify Build Data
   <meta name="turbo-cache-control" content="no-cache">
 <% end %>
 
-<% content_for :page_head_css do %>
-  <%= vite_stylesheet_tag "data_viz_css", "data-turbo-track": "reload" %>
-<% end %>
-
-<% content_for :page_head_js do %>
-  <%= vite_javascript_tag "dashboard", "data-turbo-track": "reload", defer: true %>
-<% end %>
-
 <section class="margin-bottom--m" data-controller="years" data-years-status-value="loading">
   <% button_group do %>
     <div data-years-target="buttonGroup">
@@ -84,3 +76,6 @@ title: Netlify Build Data
     <% end %>
   </div>
 </section>
+
+<%= vite_stylesheet_tag "data_viz_css", "data-turbo-track": "reload" %>
+<%= vite_javascript_tag "dashboard", "data-turbo-track": "reload", defer: true %>


### PR DESCRIPTION
The dashboard was previously doing a full page reload on a visit to the dashboard page but this no longer happens and reduces the hits on the functions